### PR TITLE
Remove unecessary dependencies

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -2,7 +2,11 @@
 
 "use strict";
 
-require("make-promises-safe");
+process.on("unhandledRejection", function unhandledRejection(error) {
+    console.error(error);
+    process.exit(1);
+});
+
 require("dotenv").config();
 
 // Require Node.js Dependencies
@@ -15,7 +19,6 @@ const { yellow, grey, white, green, cyan, red } = require("kleur");
 const sade = require("sade");
 const pacote = require("pacote");
 const Spinner = require("@slimio/async-cli-spinner");
-const filenamify = require("filenamify");
 const semver = require("semver");
 const ms = require("ms");
 const qoa = require("qoa");
@@ -23,7 +26,7 @@ const qoa = require("qoa");
 // Require Internal Dependencies
 const startHTTPServer = require("../src/httpServer.js");
 const i18n = require("../src/i18n");
-const { getRegistryURL, loadNsecureCache, writeNsecureCache } = require("../src/utils");
+const { getRegistryURL, loadNsecureCache, writeNsecureCache, filenamify } = require("../src/utils");
 const { depWalker } = require("../src/depWalker");
 const { hydrateDB, deleteDB } = require("../src/vulnerabilities");
 const { cwd, verify } = require("../index");

--- a/index.js
+++ b/index.js
@@ -8,14 +8,13 @@ const { promisify } = require("util");
 
 // Require Third-party Dependencies
 const pacote = require("pacote");
-const uniqueSlug = require("unique-slug");
 const { runASTAnalysis } = require("js-x-ray");
 const ntlp = require("ntlp");
 const isMinified = require("is-minified-code");
 
 // Require Internal Dependencies
 const { depWalker } = require("./src/depWalker");
-const { getRegistryURL, getTarballComposition } = require("./src/utils");
+const { getRegistryURL, getTarballComposition, uniqueSlug } = require("./src/utils");
 
 // CONSTANTS
 const TMP = os.tmpdir();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nsecure",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4903,7 +4903,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.1",
@@ -5509,21 +5510,6 @@
         }
       }
     },
-    "filename-reserved-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
-    },
-    "filenamify": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
-      "integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
-      "requires": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.1",
-        "trim-repeated": "^1.0.0"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5911,11 +5897,6 @@
         "gar": "^1.0.4",
         "tiny-each-async": "2.0.3"
       }
-    },
-    "get-port": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-stdin": {
       "version": "7.0.0",
@@ -8781,11 +8762,6 @@
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -8879,11 +8855,6 @@
         "socks-proxy-agent": "^5.0.0",
         "ssri": "^8.0.0"
       }
-    },
-    "make-promises-safe": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/make-promises-safe/-/make-promises-safe-5.1.0.tgz",
-      "integrity": "sha512-AfdZ49rtyhQR/6cqVKGoH7y4ql7XkS5HJI1lZm0/5N6CQosy1eYbBJ/qbhkKHzo17UH7M918Bysf6XB9f3kS1g=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -11729,14 +11700,6 @@
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
-    "strip-outer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-      "requires": {
-        "escape-string-regexp": "^1.0.2"
-      }
-    },
     "style-loader": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.1.3.tgz",
@@ -12199,14 +12162,6 @@
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
-    },
-    "trim-repeated": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-      "requires": {
-        "escape-string-regexp": "^1.0.2"
-      }
     },
     "trim-right": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint": "^6.8.0",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "^6.0.0",
+    "httpie": "^1.1.2",
     "get-folder-size": "^2.0.1",
     "gravatar-url": "^3.1.0",
     "husky": "^4.2.3",
@@ -94,17 +95,12 @@
     "cacache": "^15.0.0",
     "combine-async-iterators": "^1.1.2",
     "dotenv": "^8.2.0",
-    "filenamify": "^4.1.0",
-    "get-port": "^5.1.1",
-    "httpie": "^1.1.2",
     "is-minified-code": "^2.0.0",
     "itertools": "^1.6.0",
     "js-x-ray": "^1.6.0",
     "kleur": "^3.0.3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.difference": "^4.5.0",
-    "lodash.get": "^4.4.2",
-    "make-promises-safe": "^5.1.0",
     "ms": "^2.1.2",
     "ntlp": "^1.1.3",
     "open": "^7.0.3",
@@ -114,7 +110,6 @@
     "sade": "^1.7.3",
     "semver": "^7.1.3",
     "sirv": "^0.4.2",
-    "unique-slug": "^2.0.2",
     "zup": "0.0.1"
   }
 }

--- a/src/httpServer.js
+++ b/src/httpServer.js
@@ -88,7 +88,7 @@ async function startHTTPServer(dataFilePath, configPort) {
     });
 
     /* istanbul ignore next */
-    const port = typeof configPort === "number" ? configPort : await getPort();
+    const port = typeof configPort === "number" ? configPort : await getPort(8080);
     httpServer.listen(port, () => {
         const link = `http://localhost:${port}`;
         console.log(kleur.magenta().bold(i18n.getToken("cli.http_server_started")), kleur.cyan().bold(link));

--- a/src/httpServer.js
+++ b/src/httpServer.js
@@ -14,12 +14,12 @@ const polka = require("polka");
 const send = require("@polka/send-type");
 const sirv = require("sirv");
 const open = require("open");
-const getPort = require("get-port");
 const kleur = require("kleur");
 const zup = require("zup");
 
 // Require Internal Dependencies
 const i18n = require("./i18n");
+const { getPort } = require("./utils");
 
 // CONSTANTS
 const VIEWS = join(__dirname, "..", "views");

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,7 +7,9 @@ const { join } = require("path");
 
 // Require Third-party Depedencies
 const cacache = require("cacache");
-const get = require("lodash.get");
+
+// Require Internal Dependencies
+const { get } = require("./utils");
 
 // CONSTANTS
 const kCachePath = join(os.tmpdir(), "nsecure-cli");

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,9 @@ const {
 const { extname, join, relative } = require("path");
 const { spawnSync } = require("child_process");
 
+// Require Third-party Dependencies
+const cloneDeep = require("lodash.clonedeep");
+
 // SYMBOLS
 const SYM_FILE = Symbol("symTypeFile");
 const SYM_DIR = Symbol("symTypeDir");
@@ -140,7 +143,7 @@ function loadNsecureCache(defaultPayload = {}) {
         return JSON.parse(buf.toString());
     }
 
-    const payload = Object.assign({}, JSON.parse(JSON.stringify(defaultPayload)), {
+    const payload = Object.assign({}, cloneDeep(defaultPayload), {
         lastUpdated: Date.now() - (3600000 * 48)
     });
     writeFileSync(filePath, JSON.stringify(payload));
@@ -224,6 +227,9 @@ function checkPortAvailability(port) {
 }
 
 async function getPort(portNumber) {
+    if (portNumber <= 1024) {
+        throw new Error("Invalid port number");
+    }
     let idx = portNumber;
 
     while (idx < 65535) {

--- a/test/getTarballComposition.js
+++ b/test/getTarballComposition.js
@@ -25,5 +25,5 @@ test("should return the composition of a directory", async() => {
         size
     });
     expect(composition.files).toHaveLength(4);
-    expect(composition.files[0]).toMatch(/one(\/|\\)README/);
+    expect(composition.files.sort()[0]).toMatch(/one(\/|\\)README/);
 });


### PR DESCRIPTION
## Purpose

This is a very nice project, I like everything that tries to make Javascript ecosystem more secure ;-)
And especially if the tool comes with a nice CLI and GUI :D 

The purpose of this PR is to try try to get ride of some of the dependencies used by `nsecure`.  

This is motivated by:
 - reduce total downloaded code
 - reduce potential attack surface

The following dependencies have been removed:
 - `filenamify`
 - `get-port`
 - `lodash.get`
 - `make-promise-safe`
 - `unique-slug`

(`httpie` has just been moved to `devDependencies`)

I think you could also get ride of these dependencies:
 -  `is-minified-code` the algorithm is pretty straightforward 
 - `itertools` fortunately the STD lib offer a wide range of functionalities on collection  
 - `lodash.clonedeep` you could simply use `JSON.parse(JSON.stringify(..))`` for most of your use cases (you may need to stop using symbol to declare class member thus)

