### PR TITLE
fix(i18n): typos and consistency

### DIFF
--- a/i18n/english.js
+++ b/i18n/english.js
@@ -8,57 +8,57 @@ module.exports = {
     lang: "en",
     cli: {
         executing_at: "Executing node-secure at",
-        min_nodejs_version: tS`node-secure require at least Node.js ${0} to work! Please upgrade your Node.js version.`,
-        no_dep_to_proceed: "No dependencies to proceed !",
-        successfully_written_json: tS`Successfully written .json file at: ${0}`,
-        http_server_started: "HTTP Server started",
+        min_nodejs_version: tS`node-secure requires at least Node.js ${0} to work! Please upgrade your Node.js version.`,
+        no_dep_to_proceed: "No dependencies to proceed!",
+        successfully_written_json: tS`Successfully written results file at: ${0}`,
+        http_server_started: "HTTP Server started on:",
         commands: {
-            option_depth: "maximum dependencies depth to fetch",
-            option_output: "json file output name",
+            option_depth: "Maximum dependencies depth to fetch",
+            option_output: "Json file output name",
             hydrate_db: {
                 desc: "Hydrate the vulnerabilities db",
-                running: tS`Hydrating local vulnerabilities with the '${0}' database!`,
+                running: tS`Hydrating local vulnerabilities with the '${0}' database...`,
                 success: tS`Successfully hydrated vulnerabilities database in ${0}`
             },
             cwd: {
                 desc: "Run security analysis on the current working dir",
-                option_nolock: "disable usage of package-lock.json",
-                option_full: "enable full analysis of packages in the package-lock.json file"
+                option_nolock: "Disable usage of package-lock.json",
+                option_full: "Enable full analysis of packages in the package-lock.json file"
             },
             from: {
                 desc: "Run security analysis on a given package from npm registry",
-                searching: tS`Searching for '${0}' manifest in the npm registry!`,
+                searching: tS`Searching for '${0}' manifest in the npm registry...`,
                 fetched: tS`Fetched ${0} manifest from npm in ${1}`
             },
             auto: {
                 desc: "Run security analysis on cwd or a given package and automatically open the web interface",
-                option_keep: "keep the nsecure-result.json file on the system after execution"
+                option_keep: "Keep the nsecure-result.json file on the system after execution"
             },
             open: {
-                desc: "Run an HTTP Server with a given nsecure JSON file."
+                desc: "Run an HTTP Server with a given nsecure JSON file"
             },
             verify: {
-                desc: "Run a complete advanced analysis for a given npm package!",
+                desc: "Run a complete advanced analysis for a given npm package",
                 option_json: "Stdout the analysis payload"
             },
             lang: {
-                desc: "Configure the CLI default language.",
-                question_text: "What language do you want?",
+                desc: "Configure the CLI default language",
+                question_text: "What language do you want to use?",
                 new_selection: tS`'${0}' has been selected as the new CLI language!`
             }
         }
     },
     depWalker: {
         dep_tree: "dependency tree",
-        fetch_and_walk_deps: "Fetching and walking through all dependencies ...",
-        fetch_on_registry: "Waiting for packages to fetch from npm registry!",
-        waiting_tarball: "Waiting tarballs to be analyzed!",
+        fetch_and_walk_deps: "Fetching and walking through all dependencies...",
+        fetch_on_registry: "Waiting for packages to fetch from npm registry...",
+        waiting_tarball: "Waiting tarballs to be analyzed...",
         fetch_metadata: "Fetched package metadata:",
         analyzed_tarball: "Analyzed npm tarballs:",
         success_fetch_deptree: tS`Successfully navigated through the ${0} in ${1}`,
-        success_tarball: tS`Successfully analyzed ${0} packages tarball in ${1}`,
+        success_tarball: tS`Successfully analyzed ${0} packages tarballs in ${1}`,
         success_registry_metadata: "Successfully fetched required metadata for all packages!",
-        failed_rmdir: tS`Failed to remove directory ${0}`
+        failed_rmdir: tS`Failed to remove directory ${0}!`
     },
     ui: {
         stats: {
@@ -92,7 +92,6 @@ module.exports = {
             warnings: {
                 title: "Warnings",
                 homepage: "Homepage",
-                linkhere: "link here",
                 type: "type",
                 file: "file",
                 errorMsg: "incrimined value",
@@ -100,8 +99,8 @@ module.exports = {
             }
         },
         searchbar_placeholder: "Search",
-        btn_emojis_legends: "Emojis Legends",
-        show_complete_desc: "click on a package to show a complete description here",
+        btn_emojis_legends: "Emojis legend",
+        show_complete_desc: "Select a package to show a complete description here",
         loading_nodes: "... Loading nodes ...",
         please_wait: "(Please wait)"
     }

--- a/i18n/french.js
+++ b/i18n/french.js
@@ -8,64 +8,64 @@ module.exports = {
     lang: "fr",
     cli: {
         executing_at: "Exécution de node-secure à",
-        min_nodejs_version: tS`node-secure demande au moins Node.js ${0} pour fonctionner! Merci de mettre à jour votre version de Node.js.`,
+        min_nodejs_version: tS`node-secure nécessite au moins Node.js ${0} pour fonctionner ! Merci de mettre à jour votre version de Node.js.`,
         no_dep_to_proceed: "Aucune dépendance pour continuer !",
-        successfully_written_json: tS`Ecriture du fichier .json ${0} réalisé avec succès`,
-        http_server_started: "Serveur HTTP démarré sur l'URL suivante:",
+        successfully_written_json: tS`Ecriture du fichier de résultats réalisée avec succès ici : ${0}`,
+        http_server_started: "Serveur HTTP démarré sur :",
         commands: {
             option_depth: "Niveau de profondeur de dépendances maximum à aller chercher",
             option_output: "Nom de sortie du fichier json",
             hydrate_db: {
                 desc: "Mise à jour de la base de vulnérabilité",
-                running: tS`Mise à jour local des vulnérabilités avec la base '${0}'!`,
+                running: tS`Mise à jour locale des vulnérabilités avec la base '${0}'...`,
                 success: tS`Base de vulnérabilités mise à jour avec succès en ${0}`
             },
             cwd: {
-                desc: "Démarre une analyse de sécurité sur le cwd",
-                option_nolock: "déactivation de l'utilisation du package-lock.json",
-                option_full: "active l'analyse complète des packages présent dans le package-lock.json"
+                desc: "Démarre une analyse de sécurité sur le dossier courant",
+                option_nolock: "Désactive l'utilisation du package-lock.json",
+                option_full: "Active l'analyse complète des packages présents dans le package-lock.json"
             },
             from: {
                 desc: "Démarre une analyse de sécurité sur un package donné du registre npm",
-                searching: tS`Recherche du manifest '${0}' dans le registre npm!`,
+                searching: tS`Recherche du manifest '${0}' dans le registre npm...`,
                 fetched: tS`Manifest du package ${0} importé de npm en ${1}`
             },
             auto: {
-                desc: "Démarre une analyse de sécurité sur le cwd ou sur un package donné et ouvre automatiquement l'interface web",
+                desc: "Démarre une analyse de sécurité sur le dossier courant ou sur un package donné et ouvre automatiquement l'interface web",
                 option_keep: "Conserve le fichier nsecure-result.json sur le systeme après l'exécution"
             },
             open: {
-                desc: "Démarre un serveur HTTP avec un fichier .json nsecure donné."
+                desc: "Démarre un serveur HTTP avec un fichier .json nsecure donné"
             },
             verify: {
-                desc: "Démarre une analyse AST avancé pour un package npm donné!",
+                desc: "Démarre une analyse AST avancée pour un package npm donné",
                 option_json: "Affiche le résultat d'analyse dans la sortie standard"
             },
             lang: {
-                desc: "Configure le langage par défaut du CLI.",
-                question_text: "Quel langage voulez-vous?",
-                new_selection: tS`'${0}' a été selectionné comme étant le nouveau langage du CLI!`
+                desc: "Configure le langage par défaut du CLI",
+                question_text: "Quel langage souhaitez-vous utiliser ?",
+                new_selection: tS`'${0}' a été selectionné comme étant le nouveau langage du CLI !`
             }
         }
     },
     depWalker: {
         dep_tree: "arbre de dépendances",
         fetch_and_walk_deps: "Importation et analyse de l'intégralité des dépendances...",
-        fetch_on_registry: "En attente de l'importation des packages du registre npm!",
-        waiting_tarball: "En attente de l'analyse des tarballs!",
-        fetch_metadata: "Metadata package importé:",
-        analyzed_tarball: "Tarballs en cours d'analyses:",
-        success_fetch_deptree: tS`Analyse de l'${0} terminé avec succès en ${1}`,
-        success_tarball: tS`${0} tarball analysés avec succès en ${1}`,
-        success_registry_metadata: "Metadata requis pour tous les packages importé avec succès!",
-        failed_rmdir: tS`Suppression du dossier ${0} échoué`
+        fetch_on_registry: "En attente de l'importation des packages du registre npm...",
+        waiting_tarball: "En attente de l'analyse des tarballs...",
+        fetch_metadata: "Metadonnées importées :",
+        analyzed_tarball: "Tarballs en cours d'analyse :",
+        success_fetch_deptree: tS`Analyse de l'${0} terminée avec succès en ${1}`,
+        success_tarball: tS`${0} tarballs analysés avec succès en ${1}`,
+        success_registry_metadata: "Metadonnées requises pour tous les packages importées avec succès !",
+        failed_rmdir: tS`Suppression du dossier ${0} échouée !`
     },
     ui: {
         stats: {
             title: "Stats Globales",
             total_packages: "Total des packages",
-            total_size: "Poid total",
-            indirect_deps: "Packages avec déps indirectes",
+            total_size: "Poids total",
+            indirect_deps: "Packages avec dépendances indirectes",
             extensions: "Extensions",
             licenses: "Licences",
             maintainers: "Mainteneurs"
@@ -77,11 +77,11 @@ module.exports = {
             files_extensions: "extensions des fichiers",
             unused_deps: "dépendances non utilisées ",
             missing_deps: "dépendances manquantes",
-            minified_files: "Fichiers minifiées",
+            minified_files: "fichiers minifiées",
             node_deps: "dépendances node.js",
             third_party_deps: "dépendances tierces",
-            required_files: "Fichiers requis",
-            used_by: "Utilisé par"
+            required_files: "fichiers requis",
+            used_by: "utilisé par"
         },
         popups: {
             licenses: {
@@ -92,16 +92,15 @@ module.exports = {
             warnings: {
                 title: "Warnings",
                 homepage: "Page d'accueil",
-                linkhere: "lien ici",
                 type: "type",
                 file: "fichier",
-                errorMsg: "valeur incriminé",
+                errorMsg: "valeur incriminée",
                 position: "position"
             }
         },
         searchbar_placeholder: "Recherche",
-        btn_emojis_legends: "Legendes des Emojis",
-        show_complete_desc: "Cliquer sur un package pour voir une description complète ici",
+        btn_emojis_legends: "Légende des émojis",
+        show_complete_desc: "Sélectionnez un package pour voir une description complète ici",
         loading_nodes: "... Chargement des noeuds ...",
         please_wait: "(Merci de patienter)"
     }


### PR DESCRIPTION
Fix typos and add consistency:
- Capitalize and remove punctuation from commands descriptions
- Add `...` at the end of running commands
- Add spaces before punctuation for `fr`, remove for `en`
- Removed `ui.popups.warnings.linkhere` as it is not used (should we keep it?)