### PR TITLE
feat: add a preview of the incriminated code during mouse over

### DIFF
--- a/i18n/english.js
+++ b/i18n/english.js
@@ -95,7 +95,8 @@ module.exports = {
                 type: "type",
                 file: "file",
                 errorMsg: "incrimined value",
-                position: "position"
+                position: "position",
+                inspect: "inspect"
             }
         },
         searchbar_placeholder: "Search",

--- a/i18n/french.js
+++ b/i18n/french.js
@@ -95,7 +95,8 @@ module.exports = {
                 type: "type",
                 file: "fichier",
                 errorMsg: "valeur incriminée",
-                position: "position"
+                position: "position",
+                inspect: "inspecter"
             }
         },
         searchbar_placeholder: "Recherche",

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -59,6 +59,25 @@
             overflow-y: auto;
         }
 
+.modal .tooltip {
+    visibility: hidden;
+    position: absolute;
+    z-index: 1;
+    min-width: 120px;
+    max-width: 600px;
+    max-height: 300px;
+    overflow-y: auto;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%);
+    background: #212121;
+    border: 1px solid #424242;
+    color: #E1F5FE;
+    padding: 10px;
+    border-radius: 4px;
+    text-align: left;
+}
+
 .flags-legend-tags > .platine-button-skin {
     height: 30px;
     justify-content: start;

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -76,6 +76,10 @@
     padding: 10px;
     border-radius: 4px;
     text-align: left;
+    font-size: 14px;
+    font-family: "mononoki";
+    letter-spacing: 0.5px;
+    word-wrap: break-word;
 }
 
 .flags-legend-tags > .platine-button-skin {

--- a/public/css/reset.css
+++ b/public/css/reset.css
@@ -141,24 +141,3 @@ table {
     table tr td.position {
         cursor: pointer;
     }
-    table tr td.position:hover .tooltip {
-        visibility: visible;
-    }
-    table tr td.position .tooltip {
-        visibility: hidden;
-        position: absolute;
-        z-index: 1;
-        min-width: 120px;
-        max-width: 600px;
-        max-height: 300px;
-        overflow-y: auto;
-        top: 40px;
-        left: 50%;
-        transform: translate(-50%);
-        background: #212121;
-        border: 1px solid #424242;
-        color: #E1F5FE;
-        padding: 10px;
-        border-radius: 4px;
-        text-align: left;
-    }

--- a/public/css/reset.css
+++ b/public/css/reset.css
@@ -152,6 +152,10 @@ table {
         max-width: 600px;
         right: 100px;
         bottom: 40px;
-        background: #B0BEC5;
+        background: #212121;
+        border: 1px solid #424242;
+        color: #E1F5FE;
         padding: 10px;
+        border-radius: 4px;
+        text-align: left;
     }

--- a/public/css/reset.css
+++ b/public/css/reset.css
@@ -138,3 +138,20 @@ table {
         font-weight: bold;
         font-family: "Roboto";
     }
+    table tr td.position {
+        cursor: pointer;
+    }
+    table tr td.position:hover .tooltip {
+        visibility: visible;
+    }
+    table tr td.position .tooltip {
+        visibility: hidden;
+        position: absolute;
+        z-index: 1;
+        min-width: 120px;
+        max-width: 600px;
+        right: 100px;
+        bottom: 40px;
+        background: #B0BEC5;
+        padding: 10px;
+    }

--- a/public/css/reset.css
+++ b/public/css/reset.css
@@ -138,6 +138,6 @@ table {
         font-weight: bold;
         font-family: "Roboto";
     }
-    table tr td.position {
+    table tr td.inspect {
         cursor: pointer;
     }

--- a/public/css/reset.css
+++ b/public/css/reset.css
@@ -152,8 +152,9 @@ table {
         max-width: 600px;
         max-height: 300px;
         overflow-y: auto;
-        right: 100px;
-        bottom: 40px;
+        top: 40px;
+        left: 50%;
+        transform: translate(-50%);
         background: #212121;
         border: 1px solid #424242;
         color: #E1F5FE;

--- a/public/css/reset.css
+++ b/public/css/reset.css
@@ -150,6 +150,8 @@ table {
         z-index: 1;
         min-width: 120px;
         max-width: 600px;
+        max-height: 300px;
+        overflow-y: auto;
         right: 100px;
         bottom: 40px;
         background: #212121;

--- a/public/js/popup.js
+++ b/public/js/popup.js
@@ -83,22 +83,18 @@ function warningModal(clone, options) {
         const errorCell = line.insertCell(2);
         errorCell.classList.add("highlight");
         errorCell.classList.add("msg");
-
-        const positionCell = line.insertCell(3);
-        positionCell.classList.add("position");
-        if (kind !== "short-identifiers" && kind !== "obfuscated-code") {
-            positionCell.addEventListener("mouseenter", (event) => fetchCodeLine(event.srcElement, unpkgFile, location, cache, lineId))
-        }
-
         if (value !== null) {
             errorCell.classList.add("clickable");
             errorCell.appendChild(document.createTextNode(value));
             errorCell.addEventListener("click", () => utils.copyToClipboard(value));
         }
 
-        const tooltip = utils.createDOMElement('div');
-        tooltip.classList.add('tooltip');
-
+        const positionCell = line.insertCell(3);
+        positionCell.classList.add("position");
+        if (!file.includes(".min") && kind !== "short-identifiers" && kind !== "obfuscated-code") {
+            const currLocation = kind === "encoded-literal" ? location[0] : location;
+            positionCell.addEventListener("mouseenter", (event) => fetchCodeLine(event.srcElement, unpkgFile, currLocation, cache, lineId))
+        }
         if (kind === "encoded-literal") {
             const text = location.map((loc) => locationToString(loc)).join(" // ");
             positionCell.appendChild(document.createTextNode(text));
@@ -106,6 +102,8 @@ function warningModal(clone, options) {
         else {
             positionCell.appendChild(document.createTextNode(locationToString(location)));
         }
+
+        const tooltip = utils.createDOMElement('div', { classList: ['tooltip'] });
         positionCell.appendChild(tooltip);
     }
 

--- a/public/js/popup.js
+++ b/public/js/popup.js
@@ -37,7 +37,6 @@ function getLineFromFile(code, location) {
 
 async function fetchCodeLine(event, url, location, cache, lineId) {
     const target = document.getElementById('tooltip');
-
     target.style.visibility = 'visible';
 
     if (cache.has(lineId)) {
@@ -111,16 +110,20 @@ function warningModal(clone, options) {
 
         const positionCell = line.insertCell(3);
         positionCell.classList.add("position");
-        if (!file.includes(".min") && kind !== "short-identifiers" && kind !== "obfuscated-code") {
-            const currLocation = kind === "encoded-literal" ? location[0] : location;
-            positionCell.addEventListener("click", (event) => fetchCodeLine(event, unpkgFile, currLocation, cache, lineId))
-        }
         if (kind === "encoded-literal") {
             const text = location.map((loc) => locationToString(loc)).join(" // ");
             positionCell.appendChild(document.createTextNode(text));
         }
         else {
             positionCell.appendChild(document.createTextNode(locationToString(location)));
+        }
+
+        const inspectCell = line.insertCell(4);
+        inspectCell.innerHTML = "🔬";
+        inspectCell.classList.add("inspect");
+        if (!file.includes(".min") && kind !== "short-identifiers" && kind !== "obfuscated-code") {
+            const currLocation = kind === "encoded-literal" ? location[0] : location;
+            inspectCell.addEventListener("click", (event) => fetchCodeLine(event, unpkgFile, currLocation, cache, lineId));
         }
     }
 
@@ -130,9 +133,9 @@ function warningModal(clone, options) {
 }
 
 export function openLicenseModal(options = {}) {
-    return () => window.toggleModal("popup-license", (clone) => licenseModal(clone, options))
+    return () => window.toggleModal("popup-license", (clone) => licenseModal(clone, options));
 }
 
 export function openWarningsModal(options = {}) {
-    return () => window.toggleModal("popup-warning", (clone) => warningModal(clone, options))
+    return () => window.toggleModal("popup-warning", (clone) => warningModal(clone, options));
 }

--- a/views/index.html
+++ b/views/index.html
@@ -83,6 +83,7 @@
 </section>
 
 <div class="modal">
+    <div class="tooltip" id="tooltip"></div>
     <div class="modal-content dark-box-skin">
         <span class="close-button">&times;</span>
         <div class="infobox"></div>

--- a/views/index.html
+++ b/views/index.html
@@ -231,6 +231,7 @@
                     <th class="sort" data-sort="file">[[=z.token('popups.warnings.file')]]</th>
                     <th class="sort" data-sort="msg">[[=z.token('popups.warnings.errorMsg')]]</th>
                     <th class="sort" data-sort="position">[[=z.token('popups.warnings.position')]]</th>
+                    <th class="sort" data-sort="position">[[=z.token('popups.warnings.inspect')]]</th>
                 </tr>
             </thead>
             <tbody class="list"></tbody>


### PR DESCRIPTION
Hi @fraxken  👋  

Very happy to submit you this pull request related the issue #48 ^^

I think we should consider the fact that each request to UNPKG should be cached. I'm not really opinionated about the way to do it. This is why I prefer to ask you first. I could propose something anyway.

A little preview:
![nsecure](https://user-images.githubusercontent.com/22824417/93670336-00e36980-fa9b-11ea-9b3c-05773ddb9c48.gif)
