### PR TITLE
fix: move bundlephobia call in the backend

### DIFF
--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -4,7 +4,6 @@ import { getJSON } from "@nodesecure/vis-network";
 
 // Import static
 import avatarURL from "../img/avatar-default.png";
-import { portStore } from "../../src/http-server/context";
 
 window.activeLegendElement = null;
 
@@ -213,10 +212,9 @@ export function copyToClipboard(str) {
 
 export async function getBundlephobiaSize(name, version) {
   try {
-    const port = portStore.getStore();
     const {
       gzip, size, dependencySizes
-    } = await getJSON(`http://localhost:${port}/bundle/${name}/${version}`);
+    } = await getJSON(`/bundle/${name}/${version}`);
     const fullSize = dependencySizes.reduce((prev, curr) => prev + curr.approximateSize, 0);
 
     document.querySelector(".size-gzip").textContent = prettyBytes(gzip);

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -4,6 +4,7 @@ import { getJSON } from "@nodesecure/vis-network";
 
 // Import static
 import avatarURL from "../img/avatar-default.png";
+import { portStore } from "../../src/http-server/context";
 
 window.activeLegendElement = null;
 
@@ -212,9 +213,11 @@ export function copyToClipboard(str) {
 
 export async function getBundlephobiaSize(name, version) {
   try {
+    const port = portStore.getStore();
+    console.log({ port });
     const {
       gzip, size, dependencySizes
-    } = await getJSON(`https://bundlephobia.com/api/size?package=${name}@${version}`);
+    } = await getJSON(`http://localhost:${port}/bundle/${name}/${version}`);
     const fullSize = dependencySizes.reduce((prev, curr) => prev + curr.approximateSize, 0);
 
     document.querySelector(".size-gzip").textContent = prettyBytes(gzip);

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -214,7 +214,6 @@ export function copyToClipboard(str) {
 export async function getBundlephobiaSize(name, version) {
   try {
     const port = portStore.getStore();
-    console.log({ port });
     const {
       gzip, size, dependencySizes
     } = await getJSON(`http://localhost:${port}/bundle/${name}/${version}`);

--- a/src/commands/http.js
+++ b/src/commands/http.js
@@ -6,8 +6,8 @@ import { buildServer } from "../http-server/index.js";
 
 export async function start(json = "nsecure-result.json", options = {}) {
   const port = Number(options.port);
-
   const dataFilePath = path.join(process.cwd(), json);
+
   const httpServer = buildServer(dataFilePath, {
     port: Number.isNaN(port) ? 0 : port
   });

--- a/src/http-server/bundle.js
+++ b/src/http-server/bundle.js
@@ -17,7 +17,7 @@ export async function get(req, res) {
       dependencySizes
     });
   }
-  catch {
-    return send(res, 404, { error: "Not Found" });
+  catch (error) {
+    return send(res, error.statusCode, { error: error.statusMessage });
   }
 }

--- a/src/http-server/bundle.js
+++ b/src/http-server/bundle.js
@@ -1,0 +1,23 @@
+import { get as getRequest } from "@myunisoft/httpie";
+import send from "@polka/send-type";
+
+const kBaseBundlePhobiaUrl = "https://bundlephobia.com/api";
+
+export async function get(req, res) {
+  const { pkgName, version } = req.params;
+
+  const pkgTemplate = version ? `${pkgName}@${version}` : pkgName;
+  try {
+    const { data } = await getRequest(`${kBaseBundlePhobiaUrl}/size?package=${pkgTemplate}`);
+    const { gzip, size, dependencySizes } = data;
+
+    return send(res, 200, {
+      gzip,
+      size,
+      dependencySizes
+    });
+  }
+  catch {
+    return send(res, 404, { error: "Not Found" });
+  }
+}

--- a/src/http-server/context.js
+++ b/src/http-server/context.js
@@ -1,3 +1,5 @@
 import { AsyncLocalStorage } from "async_hooks";
 
 export const context = new AsyncLocalStorage();
+
+export const portStore = new AsyncLocalStorage();

--- a/src/http-server/context.js
+++ b/src/http-server/context.js
@@ -1,5 +1,3 @@
 import { AsyncLocalStorage } from "async_hooks";
 
 export const context = new AsyncLocalStorage();
-
-export const portStore = new AsyncLocalStorage();

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -13,6 +13,7 @@ import * as i18n from "@nodesecure/i18n";
 import * as root from "./root.js";
 import * as data from "./data.js";
 import * as flags from "./flags.js";
+import * as bundle from "./bundle.js";
 import * as middleware from "./middleware.js";
 
 export function buildServer(dataFilePath, options = {}) {
@@ -29,6 +30,8 @@ export function buildServer(dataFilePath, options = {}) {
   httpServer.get("/data", data.get);
   httpServer.get("/flags", flags.getAll);
   httpServer.get("/flags/description/:title", flags.get);
+  httpServer.get("/bundle/:pkgName", bundle.get);
+  httpServer.get("/bundle/:pkgName/:version", bundle.get);
 
   httpServer.listen(httpConfigPort, () => {
     const link = `http://localhost:${httpServer.server.address().port}`;

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -15,7 +15,6 @@ import * as data from "./data.js";
 import * as flags from "./flags.js";
 import * as bundle from "./bundle.js";
 import * as middleware from "./middleware.js";
-import { portStore } from "./context.js";
 
 export function buildServer(dataFilePath, options = {}) {
   const httpConfigPort = typeof options.port === "number" ? options.port : 0;
@@ -36,14 +35,12 @@ export function buildServer(dataFilePath, options = {}) {
 
   httpServer.listen(httpConfigPort, () => {
     const port = httpServer.server.address().port;
-    portStore.run(port, () => {
-      const link = `http://localhost:${port}`;
-      console.log(kleur.magenta().bold(i18n.getToken("cli.http_server_started")), kleur.cyan().bold(link));
+    const link = `http://localhost:${port}`;
+    console.log(kleur.magenta().bold(i18n.getToken("cli.http_server_started")), kleur.cyan().bold(link));
 
-      if (openLink) {
-        open(link);
-      }
-    });
+    if (openLink) {
+      open(link);
+    }
   });
 
   return httpServer;

--- a/src/http-server/index.js
+++ b/src/http-server/index.js
@@ -15,6 +15,7 @@ import * as data from "./data.js";
 import * as flags from "./flags.js";
 import * as bundle from "./bundle.js";
 import * as middleware from "./middleware.js";
+import { portStore } from "./context.js";
 
 export function buildServer(dataFilePath, options = {}) {
   const httpConfigPort = typeof options.port === "number" ? options.port : 0;
@@ -34,12 +35,15 @@ export function buildServer(dataFilePath, options = {}) {
   httpServer.get("/bundle/:pkgName/:version", bundle.get);
 
   httpServer.listen(httpConfigPort, () => {
-    const link = `http://localhost:${httpServer.server.address().port}`;
-    console.log(kleur.magenta().bold(i18n.getToken("cli.http_server_started")), kleur.cyan().bold(link));
+    const port = httpServer.server.address().port;
+    portStore.run(port, () => {
+      const link = `http://localhost:${port}`;
+      console.log(kleur.magenta().bold(i18n.getToken("cli.http_server_started")), kleur.cyan().bold(link));
 
-    if (openLink) {
-      open(link);
-    }
+      if (openLink) {
+        open(link);
+      }
+    });
   });
 
   return httpServer;

--- a/test/httpServer.spec.js
+++ b/test/httpServer.spec.js
@@ -86,7 +86,49 @@ test("'/data' should return the fixture payload we expect", async(tape) => {
   tape.end();
 });
 
+test("'/bundle/:name/:version' should return the bundle size", async(tape) => {
+  const result = await get(new URL("/bundle/flatstr/1.0.12", HTTP_URL));
+
+  tape.equal(result.statusCode, 200);
+  tape.equal(result.headers["content-type"], "application/json;charset=utf-8");
+  checkBundleResponse(tape, result.data);
+});
+
+test("'/bundle/:name/:version' should return an error if it fails", async(tape) => {
+  tape.plan(2);
+  const wrongVersion = undefined;
+  const wrongPackageName = "br-br-br-brah";
+
+  try {
+    await get(new URL(`/bundle/${wrongPackageName}/${wrongVersion}`, HTTP_URL));
+  }
+  catch (error) {
+    tape.equal(error.statusCode, 404);
+    tape.equal(error.data.error, "Not Found");
+  }
+
+  tape.end();
+});
+
+test("'/bundle/:name' should return the bundle size of the last version", async(tape) => {
+  const result = await get(new URL("/bundle/flatstr", HTTP_URL));
+
+  tape.equal(result.statusCode, 200);
+  tape.equal(result.headers["content-type"], "application/json;charset=utf-8");
+  checkBundleResponse(tape, result.data);
+});
+
 test("teardown", (tape) => {
   httpServer.server.close();
   tape.end();
 });
+
+/**
+ * HELPERS
+ */
+
+function checkBundleResponse(tapeInstance, payload) {
+  tapeInstance.ok(payload.gzip);
+  tapeInstance.ok(payload.size);
+  tapeInstance.ok(payload.dependencySizes);
+}

--- a/test/httpServer.spec.js
+++ b/test/httpServer.spec.js
@@ -97,10 +97,9 @@ test("'/bundle/:name/:version' should return the bundle size", async(tape) => {
 test("'/bundle/:name/:version' should return an error if it fails", async(tape) => {
   tape.plan(2);
   const wrongVersion = undefined;
-  const wrongPackageName = "br-br-br-brah";
 
   try {
-    await get(new URL(`/bundle/${wrongPackageName}/${wrongVersion}`, HTTP_URL));
+    await get(new URL(`/bundle/rimraf/${wrongVersion}`, HTTP_URL));
   }
   catch (error) {
     tape.equal(error.statusCode, 404);
@@ -116,6 +115,21 @@ test("'/bundle/:name' should return the bundle size of the last version", async(
   tape.equal(result.statusCode, 200);
   tape.equal(result.headers["content-type"], "application/json;charset=utf-8");
   checkBundleResponse(tape, result.data);
+});
+
+test("'/bundle/:name' should return an error if it fails", async(tape) => {
+  tape.plan(2);
+  const wrongPackageName = "br-br-br-brah";
+
+  try {
+    await get(new URL(`/bundle/${wrongPackageName}`, HTTP_URL));
+  }
+  catch (error) {
+    tape.equal(error.statusCode, 404);
+    tape.equal(error.data.error, "Not Found");
+  }
+
+  tape.end();
 });
 
 test("teardown", (tape) => {


### PR DESCRIPTION
Hi 👋 

This issue resolves #91 

Added:
- `bundle/:pkgName/:version` endpoint
- `bundle/:pkgName/` endpoints
- functional tests
- add storage for HTTP server port

> Note: we could switch from `bundle/:pkgName/:version` to `bundle/:pkgName?version=:v` if you prefer.